### PR TITLE
[fix][ui]: fix-18 修复前端页面样式及正则校验

### DIFF
--- a/datasophon-ui/.gitignore
+++ b/datasophon-ui/.gitignore
@@ -1,10 +1,17 @@
+# OS generated files
 .DS_Store
-node_modules/
+
+# Build directories
 dist/
-admindb/
+
+# Node.js
+node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+package-lock.json
+
+# Test coverage
 /test/unit/coverage/
 /test/e2e/reports/
 selenium-debug.log
@@ -16,5 +23,19 @@ selenium-debug.log
 *.ntvs*
 *.njsproj
 *.sln
-package-lock.json
+
+# Environment variables
+.env
+.env.development
+.env.*.local
 .env.production.local
+
+# Special directories
+admindb/
+
+# Temporary files
+~
+*~
+*.bak
+*.swp
+*.swo

--- a/datasophon-ui/src/assets/less/reset.less
+++ b/datasophon-ui/src/assets/less/reset.less
@@ -80,6 +80,18 @@
     color: #fff;
   }
 }
+.ant-modal-confirm-sure-btns-new {
+    text-align: right;
+    height: 50px;
+    display: flex;
+    align-items: center;
+    padding: 0px 20px;
+    justify-content: center;
+    margin: 0 10px 20px;
+    .ant-btn{
+        width:88px;
+    }
+}
 .ant-modal-confirm-content{
     .ant-input{
         height:40px;

--- a/datasophon-ui/src/components/menu/commponents/textCompare.vue
+++ b/datasophon-ui/src/components/menu/commponents/textCompare.vue
@@ -1,18 +1,35 @@
 <template>
   <div class="steps8">
-    <div style="display:flex; justify-content: space-between;" >
-       <div class=" w180" style="display: grid;"> 
-          <a-radio-group :default-value="currentList"  @change="changeCasting" style="margin-left:10px;"  >
-            <a-radio-button :value="item.id" v-for="(item, childIndex) in GroupList" :key="childIndex" :style="radioStyle"  button-style="solid">
-              {{item.roleGroupName}}
-            </a-radio-button>
-          </a-radio-group>
-        </div>
-      <div class="diff_list"> 
-        <code-diff v-show="!loading"  class="center" :old-string="oldStr" :new-string="newStr"  :context="context" outputFormat="side-by-side" />
+    <div style="display: flex; justify-content: space-between">
+      <div class="w180" style="display: grid">
+        <a-radio-group
+          :default-value="currentList"
+          @change="changeCasting"
+          style="margin-left: 10px"
+        >
+          <a-radio-button
+            :value="item.id"
+            v-for="(item, childIndex) in GroupList"
+            :key="childIndex"
+            :style="radioStyle"
+            button-style="solid"
+          >
+            {{ item.roleGroupName }}
+          </a-radio-button>
+        </a-radio-group>
+      </div>
+      <div class="diff_list">
+        <code-diff
+          v-show="!loading"
+          class="center"
+          :old-string="oldStr"
+          :new-string="newStr"
+          :context="context"
+          outputFormat="side-by-side"
+        />
       </div>
     </div>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-restart-btns">
       <a-button
         style="margin-right: 10px"
         type="primary"
@@ -21,12 +38,11 @@
       >
     </div>
   </div>
- 
 </template>
 <script>
-import CodeDiff from 'vue-code-diff'
+import CodeDiff from "vue-code-diff";
 export default {
-  name:'textCompare',
+  name: "textCompare",
   props: {
     serviceId: {
       type: Object,
@@ -34,9 +50,9 @@ export default {
         return {};
       },
     },
-    callBack:Function
+    callBack: Function,
   },
-  components: {CodeDiff},
+  components: { CodeDiff },
   data() {
     return {
       labelCol: {
@@ -48,91 +64,88 @@ export default {
         sm: { span: 19 },
       },
       radioStyle: {
-        display: 'block',
-        height: '30px',
-        lineHeight: '30px',
-        marginTop:'5px' ,
+        display: "block",
+        height: "30px",
+        lineHeight: "30px",
+        marginTop: "5px",
       },
       form: this.$form.createForm(this),
       value1: "",
-      loading: true ,
-      currentList:undefined,
-      GroupList:[],  //列表
-      textConfig:{},
-      modifiedVal:[],
-      origionText:[],
-      oldStr: 'old code',
-      newStr: 'new code',
-      context: 1000000 //不同地方上下间隔多少行不隐藏
+      loading: true,
+      currentList: undefined,
+      GroupList: [], //列表
+      textConfig: {},
+      modifiedVal: [],
+      origionText: [],
+      oldStr: "old code",
+      newStr: "new code",
+      context: 1000000, //不同地方上下间隔多少行不隐藏
     };
   },
-  watch: {
-  },
+  watch: {},
   methods: {
     mapTotag() {},
     formCancel() {
-      const params={
-        "roleGroupId": this.currentList,
-      }
+      const params = {
+        roleGroupId: this.currentList,
+      };
       console.log(params);
       this.$axiosPost(global.API.restartObsoleteService, params).then((res) => {
-        if (res.code !== 200) return  
+        if (res.code !== 200) return;
         this.$message.success("重启服务成功");
         this.$destroyAll();
-      })
+      });
     },
-    changeCasting(val){
+    changeCasting(val) {
       console.log(val);
-      this.currentList = val.target.value
+      this.currentList = val.target.value;
       this.handleSubmit();
-
     },
     handleSubmit() {
-      const _this = this
+      const _this = this;
       const params = {
-        "serviceInstanceId":this.serviceId.id,
-        "roleGroupId": this.currentList,
-      }
+        serviceInstanceId: this.serviceId.id,
+        roleGroupId: this.currentList,
+      };
       console.log(params);
-      this.$axiosPost(global.API.configVersionCompare, params).then((res) => {  
-        this.loading = false;
-        if (res.code !== 200) return
-        // _this.callBack();
-        console.log(res);
-        this.textConfig = res.data
-        this.origionText = res.data.oldConfig
-        this.modifiedVal = res.data.newConfig
-        this.oldStr = JSON.stringify(this.origionText, null, 4);
-        this.newStr = JSON.stringify(this.modifiedVal, null, 4);
-      }).catch((err) => {});
-      
-      
+      this.$axiosPost(global.API.configVersionCompare, params)
+        .then((res) => {
+          this.loading = false;
+          if (res.code !== 200) return;
+          // _this.callBack();
+          console.log(res);
+          this.textConfig = res.data;
+          this.origionText = res.data.oldConfig;
+          this.modifiedVal = res.data.newConfig;
+          this.oldStr = JSON.stringify(this.origionText, null, 4);
+          this.newStr = JSON.stringify(this.modifiedVal, null, 4);
+        })
+        .catch((err) => {});
     },
     getServiceRoleType() {
-      const params={
-        serviceInstanceId :this.serviceId.id
-      }
+      const params = {
+        serviceInstanceId: this.serviceId.id,
+      };
       //this.loading = true;
       //角色组列表
       this.$axiosPost(global.API.getRoleGroupList, params).then((res) => {
-        if (res.code !== 200) return  
-        this.GroupList = res.data
+        if (res.code !== 200) return;
+        this.GroupList = res.data;
         if (this.GroupList.length > 0) {
           this.currentList = this.GroupList[0].id;
-          this.handleSubmit()
+          this.handleSubmit();
         }
-        
-      })
-    }
+      });
+    },
   },
   mounted() {
-    this.getServiceRoleType()
+    this.getServiceRoleType();
   },
 };
 </script>
 <style lang="less" scoped>
 .diff_list {
-  flex:1;
+  flex: 1;
   max-height: 600px;
   overflow-y: auto;
   overflow-x: hidden;
@@ -140,13 +153,23 @@ export default {
   margin-left: 10px;
 }
 
-
- /deep/ .d2h-code-line-ctn  .hljs{
-    display: inline;
-    
-   }
+/deep/ .d2h-code-line-ctn .hljs {
+  display: inline;
+}
 /deep/ .d2h-code-side-line {
   height: 18px;
+}
+.ant-modal-restart-btns {
+  text-align: right;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  padding: 0px 20px;
+  justify-content: center;
+  margin: 0 10px 20px;
+  .ant-btn {
+    width: 116px;
+  }
 }
 // /deep/ .d2h-wrapper>.d2h-code-side-line,
 // .d2h-wrapper .d2h-code-line {

--- a/datasophon-ui/src/pages/alarmManage/commponents/addGroup.vue
+++ b/datasophon-ui/src/pages/alarmManage/commponents/addGroup.vue
@@ -27,7 +27,7 @@
   <div style="padding-top: 20px">
     <a-form
       :label-col="labelCol"
-      :wrapper-col="wrapperCol" 
+      :wrapper-col="wrapperCol"
       :form="form"
       class="p0-32-10-32 form-content"
     >
@@ -42,12 +42,23 @@
         />
       </a-form-item>
       <a-form-item label="告警组类别">
-          <a-select v-decorator="['alertGroupCategory', { rules: [{ required: true, message: '告警组类别不能为空!' }]}]"  placeholder="请选择告警组类别">
-               <a-select-option :value="item.serviceName" v-for="(item,index) in cateList" :key="index">{{item.serviceName}}</a-select-option>
-          </a-select>
+        <a-select
+          v-decorator="[
+            'alertGroupCategory',
+            { rules: [{ required: true, message: '告警组类别不能为空!' }] },
+          ]"
+          placeholder="请选择告警组类别"
+        >
+          <a-select-option
+            :value="item.serviceName"
+            v-for="(item, index) in cateList"
+            :key="index"
+            >{{ item.serviceName }}</a-select-option
+          >
+        </a-select>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"
@@ -68,7 +79,7 @@ export default {
         return {};
       },
     },
-    callBack:Function
+    callBack: Function,
   },
   data() {
     return {
@@ -84,7 +95,7 @@ export default {
       form: this.$form.createForm(this),
       value1: "",
       loading: false,
-      cateList: [] //告警组类别列表
+      cateList: [], //告警组类别列表
     };
   },
   watch: {},
@@ -93,49 +104,59 @@ export default {
       this.$destroyAll();
     },
     handleSubmit(e) {
-      const _this = this
+      const _this = this;
       e.preventDefault();
       this.form.validateFields((err, values) => {
         if (!err) {
           const params = {
-            "alertGroupName": values.alertGroupName, 
-            "alertGroupCategory": values.alertGroupCategory,
-            clusterId: this.clusterId
-          }
-          if (JSON.stringify(this.detail) !== '{}') params.id = this.detail.id
+            alertGroupName: values.alertGroupName,
+            alertGroupCategory: values.alertGroupCategory,
+            clusterId: this.clusterId,
+          };
+          if (JSON.stringify(this.detail) !== "{}") params.id = this.detail.id;
           this.loading = true;
-          const ajaxApi = JSON.stringify(this.detail) !== '{}' ? global.API.saveGroup : global.API.saveGroup
-          this.$axiosJsonPost(ajaxApi, params).then((res) => {  
-            this.loading = false;
-            if (res.code === 200) {
-              this.$message.success('保存成功', 2)
-              this.$destroyAll();
-              _this.callBack();
-            }
-          }).catch((err) => {});
+          const ajaxApi =
+            JSON.stringify(this.detail) !== "{}"
+              ? global.API.saveGroup
+              : global.API.saveGroup;
+          this.$axiosJsonPost(ajaxApi, params)
+            .then((res) => {
+              this.loading = false;
+              if (res.code === 200) {
+                this.$message.success("保存成功", 2);
+                this.$destroyAll();
+                _this.callBack();
+              }
+            })
+            .catch((err) => {});
         }
       });
     },
     getAlarmCate() {
-      this.$axiosPost(global.API.getAlarmCate, {clusterId: this.clusterId}).then((res) => {
+      this.$axiosPost(global.API.getAlarmCate, {
+        clusterId: this.clusterId,
+      }).then((res) => {
         if (res.code === 200) {
-          this.cateList = res.data
-          if (JSON.stringify(this.detail) !== '{}') {
-            this.form.getFieldsValue(['alertGroupName', 'alertGroupCategory', 'clusterCode'])
+          this.cateList = res.data;
+          if (JSON.stringify(this.detail) !== "{}") {
+            this.form.getFieldsValue([
+              "alertGroupName",
+              "alertGroupCategory",
+              "clusterCode",
+            ]);
             this.form.setFieldsValue({
-              alertGroupName:this.detail.alertGroupName,
+              alertGroupName: this.detail.alertGroupName,
               alertGroupCategory: this.detail.alertGroupCategory,
-              clusterCode: this.detail.clusterCode
-            })
+              clusterCode: this.detail.clusterCode,
+            });
           }
         }
-      })
-    }
+      });
+    },
   },
   mounted() {
-    this.getAlarmCate()
+    this.getAlarmCate();
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/alarmManage/commponents/addMetric.vue
+++ b/datasophon-ui/src/pages/alarmManage/commponents/addMetric.vue
@@ -25,18 +25,29 @@
 -->
 <template>
   <div style="padding-top: 20px">
-    <a-form :label-col="labelCol" :wrapper-col="wrapperCol" :form="form" class="p0-32-10-32 form-content">
+    <a-form
+      :label-col="labelCol"
+      :wrapper-col="wrapperCol"
+      :form="form"
+      class="p0-32-10-32 form-content"
+    >
       <a-form-item label="告警指标名称">
-        <a-input v-decorator="[
+        <a-input
+          v-decorator="[
             'alertQuotaName',
             { rules: [{ required: true, message: '告警指标名称不能为空!' }] },
-          ]" placeholder="请输入告警指标名称" />
+          ]"
+          placeholder="请输入告警指标名称"
+        />
       </a-form-item>
       <a-form-item label="指标表达式">
-        <a-input v-decorator="[
+        <a-input
+          v-decorator="[
             'alertExpr',
             { rules: [{ required: true, message: '指标表达式不能为空!' }] },
-          ]" placeholder="请输入指标表达式" />
+          ]"
+          placeholder="请输入指标表达式"
+        />
       </a-form-item>
       <!-- <a-form-item label="告警组类别">
         <a-select v-decorator="['serviceCategory', { rules: [{ required: true, message: '告警组类别不能为空!' }]}]" placeholder="请选择告警组类别">
@@ -44,63 +55,144 @@
         </a-select>
       </a-form-item>-->
       <a-form-item label="比较方式">
-        <a-select v-decorator="['compareMethod', { rules: [{ required: true, message: '比较方式不能为空!' }]}]" placeholder="请选择比较方式">
-          <a-select-option :value="item.value" v-for="(item,index) in compareMethodList" :key="index">{{item.label}}</a-select-option>
+        <a-select
+          v-decorator="[
+            'compareMethod',
+            { rules: [{ required: true, message: '比较方式不能为空!' }] },
+          ]"
+          placeholder="请选择比较方式"
+        >
+          <a-select-option
+            :value="item.value"
+            v-for="(item, index) in compareMethodList"
+            :key="index"
+            >{{ item.label }}</a-select-option
+          >
         </a-select>
       </a-form-item>
       <a-form-item label="告警阀值">
-        <a-input v-decorator="[
+        <a-input
+          v-decorator="[
             'alertThreshold',
             { rules: [{ required: true, message: '告警阀值不能为空!' }] },
-          ]" placeholder="请输入告警阀值" />
+          ]"
+          placeholder="请输入告警阀值"
+        />
       </a-form-item>
       <a-form-item label="告警级别">
-        <a-select v-decorator="['alertLevel', { rules: [{ required: true, message: '告警级别不能为空!' }]}]" placeholder="请选择告警级别">
-          <a-select-option :value="item.value" v-for="(item,index) in alertLevelList" :key="index">{{item.label}}</a-select-option>
+        <a-select
+          v-decorator="[
+            'alertLevel',
+            { rules: [{ required: true, message: '告警级别不能为空!' }] },
+          ]"
+          placeholder="请选择告警级别"
+        >
+          <a-select-option
+            :value="item.value"
+            v-for="(item, index) in alertLevelList"
+            :key="index"
+            >{{ item.label }}</a-select-option
+          >
         </a-select>
       </a-form-item>
       <a-form-item label="告警组">
-        <a-select v-decorator="['alertGroupId', { rules: [{ required: true, message: '告警组不能为空!' }]}]" placeholder="请选择告警组" @change="getRoleList">
-          <a-select-option :value="item.id" v-for="(item,index) in groupList" :key="index">{{item.alertGroupName}}</a-select-option>
+        <a-select
+          v-decorator="[
+            'alertGroupId',
+            { rules: [{ required: true, message: '告警组不能为空!' }] },
+          ]"
+          placeholder="请选择告警组"
+          @change="getRoleList"
+        >
+          <a-select-option
+            :value="item.id"
+            v-for="(item, index) in groupList"
+            :key="index"
+            >{{ item.alertGroupName }}</a-select-option
+          >
         </a-select>
       </a-form-item>
       <a-form-item label="绑定角色">
-        <a-select v-decorator="['serviceRoleName', { rules: [{ required: true, message: '绑定角色不能为空!' }]}]" placeholder="请选择绑定角色">
-          <a-select-option :value="item.serviceRoleName" v-for="(item,index) in roleList" :key="index">{{item.serviceRoleName}}</a-select-option>
+        <a-select
+          v-decorator="[
+            'serviceRoleName',
+            { rules: [{ required: true, message: '绑定角色不能为空!' }] },
+          ]"
+          placeholder="请选择绑定角色"
+        >
+          <a-select-option
+            :value="item.serviceRoleName"
+            v-for="(item, index) in roleList"
+            :key="index"
+            >{{ item.serviceRoleName }}</a-select-option
+          >
         </a-select>
       </a-form-item>
       <a-form-item label="通知组">
-        <a-select v-decorator="['noticeGroupId', { rules: [{ required: true, message: '通知组不能为空!' }]}]" placeholder="请选择通知组">
-          <a-select-option :value="item.value" v-for="(item,index) in noticeList" :key="index">{{item.label}}</a-select-option>
+        <a-select
+          v-decorator="[
+            'noticeGroupId',
+            { rules: [{ required: true, message: '通知组不能为空!' }] },
+          ]"
+          placeholder="请选择通知组"
+        >
+          <a-select-option
+            :value="item.value"
+            v-for="(item, index) in noticeList"
+            :key="index"
+            >{{ item.label }}</a-select-option
+          >
         </a-select>
       </a-form-item>
       <a-form-item label="告警策略">
-        <a-radio-group v-decorator="['alertTactic', { rules: [{ required: true, message: '告警策略不能为空!' }]}]" placeholder="请选择告警策略">
+        <a-radio-group
+          v-decorator="[
+            'alertTactic',
+            { rules: [{ required: true, message: '告警策略不能为空!' }] },
+          ]"
+          placeholder="请选择告警策略"
+        >
           <a-radio :value="1">单次</a-radio>
           <a-radio :value="2">连续</a-radio>
         </a-radio-group>
       </a-form-item>
       <a-form-item label="间隔时长(分钟)">
-        <a-input v-decorator="[
+        <a-input
+          v-decorator="[
             'intervalDuration',
             { rules: [{ required: true, message: '间隔时长(分钟)不能为空!' }] },
-          ]" placeholder="请输入间隔时长(分钟)" />
+          ]"
+          placeholder="请输入间隔时长(分钟)"
+        />
       </a-form-item>
       <a-form-item label="触发时长(秒)">
-        <a-input v-decorator="[
+        <a-input
+          v-decorator="[
             'triggerDuration',
             { rules: [{ required: true, message: '触发时长(秒)不能为空!' }] },
-          ]" placeholder="请输入触发时长(秒)" />
+          ]"
+          placeholder="请输入触发时长(秒)"
+        />
       </a-form-item>
       <a-form-item label="告警建议">
-        <a-input type="textarea" v-decorator="[
+        <a-input
+          type="textarea"
+          v-decorator="[
             'alertAdvice',
             { rules: [{ required: true, message: '告警建议不能为空!' }] },
-          ]" placeholder="请输入告警建议" />
+          ]"
+          placeholder="请输入告警建议"
+        />
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
-      <a-button style="margin-right: 10px" type="primary" @click.stop="handleSubmit" :loading="loading">确认</a-button>
+    <div class="ant-modal-confirm-sure-btns-new">
+      <a-button
+        style="margin-right: 10px"
+        type="primary"
+        @click.stop="handleSubmit"
+        :loading="loading"
+        >确认</a-button
+      >
       <a-button @click.stop="formCancel">取消</a-button>
     </div>
   </div>
@@ -279,5 +371,4 @@ export default {
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/alarmManage/commponents/authCluster.vue
+++ b/datasophon-ui/src/pages/alarmManage/commponents/authCluster.vue
@@ -32,12 +32,24 @@
       class="p0-32-10-32"
     >
       <a-form-item label="集群管理员">
-          <a-select mode="multiple" v-decorator="['userIds', { rules: [{ required: true, message: '集群管理员不能为空!' }]}]"  placeholder="请选择集群管理员">
-               <a-select-option :value="item.id" v-for="(item,index) in userList" :key="index">{{item.username}}</a-select-option>
-          </a-select>
+        <a-select
+          mode="multiple"
+          v-decorator="[
+            'userIds',
+            { rules: [{ required: true, message: '集群管理员不能为空!' }] },
+          ]"
+          placeholder="请选择集群管理员"
+        >
+          <a-select-option
+            :value="item.id"
+            v-for="(item, index) in userList"
+            :key="index"
+            >{{ item.username }}</a-select-option
+          >
+        </a-select>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"
@@ -58,7 +70,7 @@ export default {
         return {};
       },
     },
-    callBack:Function
+    callBack: Function,
   },
   data() {
     return {
@@ -73,7 +85,7 @@ export default {
       form: this.$form.createForm(this),
       value1: "",
       loading: false,
-      userList: [] //集群管理员列表
+      userList: [], //集群管理员列表
     };
   },
   watch: {},
@@ -82,38 +94,40 @@ export default {
       this.$destroyAll();
     },
     handleSubmit(e) {
-      const _this = this
+      const _this = this;
       e.preventDefault();
       this.form.validateFields((err, values) => {
         if (!err) {
           const params = {
-            "userIds": values.userIds
-          }
-          if (JSON.stringify(this.detail) !== '{}') params.clusterId = this.detail.id
+            userIds: values.userIds,
+          };
+          if (JSON.stringify(this.detail) !== "{}")
+            params.clusterId = this.detail.id;
           this.loading = true;
-          this.$axiosPost(global.API.authCluster, params).then((res) => {  
-            this.loading = false;
-            if (res.code === 200) {
-              this.$message.success('授权成功', 2)
-              this.$destroyAll();
-              _this.callBack();
-            }
-          }).catch((err) => {});
+          this.$axiosPost(global.API.authCluster, params)
+            .then((res) => {
+              this.loading = false;
+              if (res.code === 200) {
+                this.$message.success("授权成功", 2);
+                this.$destroyAll();
+                _this.callBack();
+              }
+            })
+            .catch((err) => {});
         }
       });
     },
     queryAllUser() {
       this.$axiosPost(global.API.queryAllUser, {}).then((res) => {
         if (res.code === 200) {
-          this.userList = res.data
+          this.userList = res.data;
         }
-      })
-    }
+      });
+    },
   },
   mounted() {
-    this.queryAllUser()
+    this.queryAllUser();
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/colonyManage/commponents/addColony.vue
+++ b/datasophon-ui/src/pages/colonyManage/commponents/addColony.vue
@@ -52,12 +52,23 @@
         />
       </a-form-item>
       <a-form-item label="集群框架">
-          <a-select v-decorator="['clusterFrame', { rules: [{ required: true, message: '集群框架不能为空!' }]}]"  placeholder="请选择集群框架">
-               <a-select-option :value="item.frameCode" v-for="(item,index) in frameList" :key="index">{{item.frameCode}}</a-select-option>
-          </a-select>
+        <a-select
+          v-decorator="[
+            'clusterFrame',
+            { rules: [{ required: true, message: '集群框架不能为空!' }] },
+          ]"
+          placeholder="请选择集群框架"
+        >
+          <a-select-option
+            :value="item.frameCode"
+            v-for="(item, index) in frameList"
+            :key="index"
+            >{{ item.frameCode }}</a-select-option
+          >
+        </a-select>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"
@@ -78,7 +89,7 @@ export default {
         return {};
       },
     },
-    callBack:Function
+    callBack: Function,
   },
   data() {
     return {
@@ -93,7 +104,7 @@ export default {
       form: this.$form.createForm(this),
       value1: "",
       loading: false,
-      frameList: [] //集群框架列表
+      frameList: [], //集群框架列表
     };
   },
   watch: {},
@@ -102,50 +113,58 @@ export default {
       this.$destroyAll();
     },
     handleSubmit(e) {
-      const _this = this
+      const _this = this;
       e.preventDefault();
       this.form.validateFields((err, values) => {
         console.log(values);
         if (!err) {
           const params = {
-            "clusterName": values.clusterName, 
-            "clusterCode": values.clusterCode, 
-            "clusterFrame": values.clusterFrame
-          }
-          if (JSON.stringify(this.detail) !== '{}') params.id = this.detail.id
+            clusterName: values.clusterName,
+            clusterCode: values.clusterCode,
+            clusterFrame: values.clusterFrame,
+          };
+          if (JSON.stringify(this.detail) !== "{}") params.id = this.detail.id;
           this.loading = true;
-          const ajaxApi = JSON.stringify(this.detail) !== '{}' ? global.API.updateColony : global.API.saveColony
-          this.$axiosJsonPost(ajaxApi, params).then((res) => {  
-            this.loading = false;
-            if (res.code === 200) {
-              this.$message.success('保存成功', 2)
-              this.$destroyAll();
-              _this.callBack();
-            }
-          }).catch((err) => {});
+          const ajaxApi =
+            JSON.stringify(this.detail) !== "{}"
+              ? global.API.updateColony
+              : global.API.saveColony;
+          this.$axiosJsonPost(ajaxApi, params)
+            .then((res) => {
+              this.loading = false;
+              if (res.code === 200) {
+                this.$message.success("保存成功", 2);
+                this.$destroyAll();
+                _this.callBack();
+              }
+            })
+            .catch((err) => {});
         }
       });
     },
     getFrameList() {
       this.$axiosPost(global.API.getFrameList, {}).then((res) => {
         if (res.code === 200) {
-          this.frameList = res.data
-          if (JSON.stringify(this.detail) !== '{}') {
-            this.form.getFieldsValue(['clusterName', 'clusterFrame', 'clusterCode'])
+          this.frameList = res.data;
+          if (JSON.stringify(this.detail) !== "{}") {
+            this.form.getFieldsValue([
+              "clusterName",
+              "clusterFrame",
+              "clusterCode",
+            ]);
             this.form.setFieldsValue({
-              clusterName:this.detail.clusterName,
+              clusterName: this.detail.clusterName,
               clusterFrame: this.detail.clusterFrame,
-              clusterCode: this.detail.clusterCode
-            })
+              clusterCode: this.detail.clusterCode,
+            });
           }
         }
-      })
-    }
+      });
+    },
   },
   mounted() {
-    this.getFrameList()
+    this.getFrameList();
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/colonyManage/commponents/authCluster.vue
+++ b/datasophon-ui/src/pages/colonyManage/commponents/authCluster.vue
@@ -32,12 +32,21 @@
       class="p0-32-10-32"
     >
       <a-form-item label="集群管理员">
-          <a-select mode="multiple" v-decorator="['userIds', { rules: [{ required: false}]}]"  placeholder="请选择集群管理员">
-               <a-select-option :value="item.id" v-for="(item,index) in userList" :key="index">{{item.username}}</a-select-option>
-          </a-select>
+        <a-select
+          mode="multiple"
+          v-decorator="['userIds', { rules: [{ required: false }] }]"
+          placeholder="请选择集群管理员"
+        >
+          <a-select-option
+            :value="item.id"
+            v-for="(item, index) in userList"
+            :key="index"
+            >{{ item.username }}</a-select-option
+          >
+        </a-select>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"
@@ -58,7 +67,7 @@ export default {
         return {};
       },
     },
-    callBack:Function
+    callBack: Function,
   },
   data() {
     return {
@@ -73,7 +82,7 @@ export default {
       form: this.$form.createForm(this),
       value1: "",
       loading: false,
-      userList: [] //集群管理员列表
+      userList: [], //集群管理员列表
     };
   },
   watch: {},
@@ -82,43 +91,45 @@ export default {
       this.$destroyAll();
     },
     handleSubmit(e) {
-      const _this = this
+      const _this = this;
       e.preventDefault();
       this.form.validateFields((err, values) => {
         console.log(values);
         if (!err) {
           const params = {
-            "userIds": values.userIds || ""
-          }
-          if (JSON.stringify(this.detail) !== '{}') params.clusterId = this.detail.id
+            userIds: values.userIds || "",
+          };
+          if (JSON.stringify(this.detail) !== "{}")
+            params.clusterId = this.detail.id;
           this.loading = true;
-          this.$axiosPost(global.API.authCluster, params).then((res) => {
-            this.loading = false;
-            if (res.code === 200) {
-              if (params.userIds.length > 0) {
-                this.$message.success('授权成功', 2)
-              }else{
-                this.$message.success('取消授权成功', 2)
+          this.$axiosPost(global.API.authCluster, params)
+            .then((res) => {
+              this.loading = false;
+              if (res.code === 200) {
+                if (params.userIds.length > 0) {
+                  this.$message.success("授权成功", 2);
+                } else {
+                  this.$message.success("取消授权成功", 2);
+                }
+                this.$destroyAll();
+                _this.callBack();
               }
-              this.$destroyAll();
-              _this.callBack();
-            }
-          }).catch((err) => {});
+            })
+            .catch((err) => {});
         }
       });
     },
     queryAllUser() {
       this.$axiosPost(global.API.queryAllUser, {}).then((res) => {
         if (res.code === 200) {
-          this.userList = res.data
+          this.userList = res.data;
         }
-      })
-    }
+      });
+    },
   },
   mounted() {
-    this.queryAllUser()
+    this.queryAllUser();
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/hostManage/addLabel.vue
+++ b/datasophon-ui/src/pages/hostManage/addLabel.vue
@@ -25,21 +25,52 @@
 -->
 <template>
   <div style="padding-top: 20px">
-    <a-form :label-col="labelCol" :wrapper-col="wrapperCol" :form="form" class="p0-32-10-32 form-content">
-      <a-form-item v-if="type ==='add'" label="标签名称">
-        <a-input id="error" v-decorator="[
+    <a-form
+      :label-col="labelCol"
+      :wrapper-col="wrapperCol"
+      :form="form"
+      class="p0-32-10-32 form-content"
+    >
+      <a-form-item v-if="type === 'add'" label="标签名称">
+        <a-input
+          id="error"
+          v-decorator="[
             'nodeLabel',
-            { rules: [{ required: true, message: '标签名称不能为空!' }, { validator: checkName }] },
-          ]" placeholder="请输入标签名称" />
+            {
+              rules: [
+                { required: true, message: '标签名称不能为空!' },
+                { validator: checkName },
+              ],
+            },
+          ]"
+          placeholder="请输入标签名称"
+        />
       </a-form-item>
       <a-form-item v-if="type !== 'add'" label="标签">
-        <a-select v-decorator="['nodeLabelId', { rules: [{ required: true, message: '标签不能为空!' }]}]" placeholder="请选择标签">
-          <a-select-option :value="item.id" v-for="(item,index) in cateList" :key="index">{{item.nodeLabel}}</a-select-option>
+        <a-select
+          v-decorator="[
+            'nodeLabelId',
+            { rules: [{ required: true, message: '标签不能为空!' }] },
+          ]"
+          placeholder="请选择标签"
+        >
+          <a-select-option
+            :value="item.id"
+            v-for="(item, index) in cateList"
+            :key="index"
+            >{{ item.nodeLabel }}</a-select-option
+          >
         </a-select>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
-      <a-button style="margin-right: 10px" type="primary" @click.stop="handleSubmit" :loading="loading">确认</a-button>
+    <div class="ant-modal-confirm-sure-btns-new">
+      <a-button
+        style="margin-right: 10px"
+        type="primary"
+        @click.stop="handleSubmit"
+        :loading="loading"
+        >确认</a-button
+      >
       <a-button @click.stop="formCancel">取消</a-button>
     </div>
   </div>
@@ -49,10 +80,10 @@ export default {
   props: {
     type: String,
     hostIds: {
-        type: Array,
-        default: () => {
-            return []
-        }
+      type: Array,
+      default: () => {
+        return [];
+      },
     },
     detail: {
       type: Object,
@@ -99,17 +130,17 @@ export default {
       e.preventDefault();
       this.form.validateFields((err, values) => {
         if (!err) {
-          if (this.type === 'add') this.savelabel(values)
-          if (this.type === 'del') this.delLabel(values)
-          if (this.type === 'handLabel') this.handLabel(values)
+          if (this.type === "add") this.savelabel(values);
+          if (this.type === "del") this.delLabel(values);
+          if (this.type === "handLabel") this.handLabel(values);
         }
       });
     },
     handLabel(values) {
-      const _this = this
+      const _this = this;
       const params = {
         nodeLabelId: values.nodeLabelId,
-        hostIds: this.hostIds
+        hostIds: this.hostIds,
       };
       this.loading = true;
       const ajaxApi = global.API.assginLabel;
@@ -174,5 +205,4 @@ export default {
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/hostManage/addRack.vue
+++ b/datasophon-ui/src/pages/hostManage/addRack.vue
@@ -25,21 +25,52 @@
 -->
 <template>
   <div style="padding-top: 20px">
-    <a-form :label-col="labelCol" :wrapper-col="wrapperCol" :form="form" class="p0-32-10-32 form-content">
-      <a-form-item v-if="type ==='add'" label="机架名称">
-        <a-input id="error" v-decorator="[
+    <a-form
+      :label-col="labelCol"
+      :wrapper-col="wrapperCol"
+      :form="form"
+      class="p0-32-10-32 form-content"
+    >
+      <a-form-item v-if="type === 'add'" label="机架名称">
+        <a-input
+          id="error"
+          v-decorator="[
             'rack',
-            { rules: [{ required: true, message: '机架名称不能为空!' }, { validator: checkName }]  },
-          ]" placeholder="请输入机架名称" />
+            {
+              rules: [
+                { required: true, message: '机架名称不能为空!' },
+                { validator: checkName },
+              ],
+            },
+          ]"
+          placeholder="请输入机架名称"
+        />
       </a-form-item>
       <a-form-item v-if="type !== 'add'" label="机架">
-        <a-select v-decorator="['rack', { rules: [{ required: true, message: '机架不能为空!' }]}]" placeholder="请选择机架">
-          <a-select-option :value="item.id" v-for="(item,index) in cateList" :key="index">{{item.rack}}</a-select-option>
+        <a-select
+          v-decorator="[
+            'rack',
+            { rules: [{ required: true, message: '机架不能为空!' }] },
+          ]"
+          placeholder="请选择机架"
+        >
+          <a-select-option
+            :value="item.id"
+            v-for="(item, index) in cateList"
+            :key="index"
+            >{{ item.rack }}</a-select-option
+          >
         </a-select>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
-      <a-button style="margin-right: 10px" type="primary" @click.stop="handleSubmit" :loading="loading">确认</a-button>
+    <div class="ant-modal-confirm-sure-btns-new">
+      <a-button
+        style="margin-right: 10px"
+        type="primary"
+        @click.stop="handleSubmit"
+        :loading="loading"
+        >确认</a-button
+      >
       <a-button @click.stop="formCancel">取消</a-button>
     </div>
   </div>
@@ -49,10 +80,10 @@ export default {
   props: {
     type: String,
     hostIds: {
-        type: Array,
-        default: () => {
-            return []
-        }
+      type: Array,
+      default: () => {
+        return [];
+      },
     },
     detail: {
       type: Object,
@@ -99,18 +130,18 @@ export default {
       e.preventDefault();
       this.form.validateFields((err, values) => {
         if (!err) {
-          if (this.type === 'add') this.saveRack(values)
-          if (this.type === 'del') this.delRack(values)
-          if (this.type === 'handRack') this.handRack(values)
+          if (this.type === "add") this.saveRack(values);
+          if (this.type === "del") this.delRack(values);
+          if (this.type === "handRack") this.handRack(values);
         }
       });
     },
     handRack(values) {
-      const _this = this
+      const _this = this;
       const params = {
         rack: values.rack,
         hostIds: this.hostIds,
-        clusterId: this.clusterId
+        clusterId: this.clusterId,
       };
       this.loading = true;
       const ajaxApi = global.API.assginRack;
@@ -175,5 +206,4 @@ export default {
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/hostManage/distributionRack.vue
+++ b/datasophon-ui/src/pages/hostManage/distributionRack.vue
@@ -27,15 +27,37 @@
 
 <template>
   <div style="padding-top: 20px">
-    <a-form :label-col="labelCol" :wrapper-col="wrapperCol" :form="form" class="p0-32-10-32 form-content">
+    <a-form
+      :label-col="labelCol"
+      :wrapper-col="wrapperCol"
+      :form="form"
+      class="p0-32-10-32 form-content"
+    >
       <a-form-item label="机架">
-        <a-select v-decorator="['rack', { rules: [{ required: true, message: '机架不能为空!' }]}]" placeholder="请选择机架">
-          <a-select-option :value="item.rack" v-for="(item,index) in frameList" :key="index">{{item.rack}}</a-select-option>
+        <a-select
+          v-decorator="[
+            'rack',
+            { rules: [{ required: true, message: '机架不能为空!' }] },
+          ]"
+          placeholder="请选择机架"
+        >
+          <a-select-option
+            :value="item.rack"
+            v-for="(item, index) in frameList"
+            :key="index"
+            >{{ item.rack }}</a-select-option
+          >
         </a-select>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
-      <a-button style="margin-right: 10px" type="primary" @click.stop="handleSubmit" :loading="loading">确认</a-button>
+    <div class="ant-modal-confirm-sure-btns-new">
+      <a-button
+        style="margin-right: 10px"
+        type="primary"
+        @click.stop="handleSubmit"
+        :loading="loading"
+        >确认</a-button
+      >
       <a-button @click.stop="formCancel">取消</a-button>
     </div>
   </div>
@@ -110,5 +132,4 @@ export default {
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/hostManage/roleModal.vue
+++ b/datasophon-ui/src/pages/hostManage/roleModal.vue
@@ -29,18 +29,26 @@
   <div class="role-model">
     <a-spin :spinning="loading">
       <div class="flex-container flex-warp">
-        <span v-for="(item, index) in dataSource" :key="index" class="flex-container role-item">
-          <span :class="['circle-point',
-          item.serviceRoleStateCode === 1
-          ? 'success-point'
-          : item.serviceRoleStateCode === 2
-          ? 'error-point'
-          : 'configured-point']" />
-          {{item.serviceRoleName}}
+        <span
+          v-for="(item, index) in dataSource"
+          :key="index"
+          class="flex-container role-item"
+        >
+          <span
+            :class="[
+              'circle-point',
+              item.serviceRoleStateCode === 1
+                ? 'success-point'
+                : item.serviceRoleStateCode === 2
+                ? 'error-point'
+                : 'configured-point',
+            ]"
+          />
+          {{ item.serviceRoleName }}
         </span>
       </div>
     </a-spin>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button @click.stop="formCancel">关闭</a-button>
     </div>
   </div>
@@ -84,8 +92,8 @@ export default {
   padding: 10px 0 0 32px;
   .flex-warp {
     flex-wrap: wrap;
-      max-height: 500px;
-      overflow-y: auto;
+    max-height: 500px;
+    overflow-y: auto;
     .role-item {
       // width: 33%;
       padding: 0 16px 10px 0;

--- a/datasophon-ui/src/pages/securityCenter/commponents/addUser.vue
+++ b/datasophon-ui/src/pages/securityCenter/commponents/addUser.vue
@@ -85,7 +85,7 @@
         />
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"
@@ -129,9 +129,15 @@ export default {
       var reg = /[\u4E00-\u9FA5]|[\uFE30-\uFFA0]/g;
       if (reg.test(value)) {
         callback(new Error("名称中不能包含中文"));
+        return;
       }
       if (/\s/g.test(value)) {
         callback(new Error("名称中不能包含空格"));
+        return;
+      }
+      if (value && value.length <= 2) {
+        callback(new Error("名称长度必须大于2个字符"));
+        return;
       }
       callback();
     },

--- a/datasophon-ui/src/pages/serviceManage/addCharacter.vue
+++ b/datasophon-ui/src/pages/serviceManage/addCharacter.vue
@@ -1,4 +1,3 @@
-
 <template>
   <div style="padding-top: 20px">
     <a-form
@@ -22,13 +21,24 @@
                <a-select-option :value="item.serviceRoleName" v-for="(item,index) in cateList" :key="index">{{item.serviceRoleName}}</a-select-option>
           </a-select>
       </a-form-item> -->
-       <a-form-item label="角色组模板">
-           <a-select v-decorator="['characterGroupId', { rules: [{ required: true, message: '角色组模板不能为空!' }]}]"  placeholder="请选择告角色组模板">
-               <a-select-option :value="item.id" v-for="(item,index) in GroupList" :key="index">{{item.roleGroupName}}</a-select-option>
-          </a-select>
+      <a-form-item label="角色组模板">
+        <a-select
+          v-decorator="[
+            'characterGroupId',
+            { rules: [{ required: true, message: '角色组模板不能为空!' }] },
+          ]"
+          placeholder="请选择告角色组模板"
+        >
+          <a-select-option
+            :value="item.id"
+            v-for="(item, index) in GroupList"
+            :key="index"
+            >{{ item.roleGroupName }}</a-select-option
+          >
+        </a-select>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"
@@ -49,13 +59,13 @@ export default {
         return {};
       },
     },
-    edit:{
-      type:Object,
+    edit: {
+      type: Object,
       default: function () {
         return {};
       },
     },
-    callBack:Function
+    callBack: Function,
   },
   data() {
     return {
@@ -71,7 +81,7 @@ export default {
       value1: "",
       loading: false,
       cateList: [], //类型
-      GroupList:[]  //列表
+      GroupList: [], //列表
     };
   },
   watch: {},
@@ -80,48 +90,48 @@ export default {
       this.$destroyAll();
     },
     handleSubmit(e) {
-      const _this = this
+      const _this = this;
       e.preventDefault();
       this.form.validateFields((err, values) => {
         if (!err) {
           const params = {
-            "roleGroupName": values.characterGroupName, 
-            "roleGroupId": values.characterGroupId,
-            serviceInstanceId: this.serviceId.id
-          }
+            roleGroupName: values.characterGroupName,
+            roleGroupId: values.characterGroupId,
+            serviceInstanceId: this.serviceId.id,
+          };
           this.loading = true;
-          this.$axiosPost(global.API.addRoleGroupSave, params).then((res) => {  
-            this.loading = false;
-            if (res.code !== 200) return
-            this.$message.success('保存角色组成功')
-            this.$destroyAll();
-            _this.callBack();
-          }).catch((err) => {});
+          this.$axiosPost(global.API.addRoleGroupSave, params)
+            .then((res) => {
+              this.loading = false;
+              if (res.code !== 200) return;
+              this.$message.success("保存角色组成功");
+              this.$destroyAll();
+              _this.callBack();
+            })
+            .catch((err) => {});
         }
       });
     },
     getServiceRoleType() {
-      const params={
-        serviceInstanceId :this.serviceId.id
-      }
+      const params = {
+        serviceInstanceId: this.serviceId.id,
+      };
       //角色组类型
       // this.$axiosPost(global.API.getServiceRoleType, params).then((res) => {
       //   if (res.code !== 200) return
       //   this.cateList = res.data
       // }
-      // ) 
+      // )
       //角色组列表
       this.$axiosPost(global.API.getRoleGroupList, params).then((res) => {
-        if (res.code !== 200) return  //this.$message.error('获取角色组列表失败')
-        this.GroupList = res.data
-        
-      })
-    }
+        if (res.code !== 200) return; //this.$message.error('获取角色组列表失败')
+        this.GroupList = res.data;
+      });
+    },
   },
   mounted() {
-    this.getServiceRoleType()
+    this.getServiceRoleType();
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/serviceManage/addQueue.vue
+++ b/datasophon-ui/src/pages/serviceManage/addQueue.vue
@@ -25,120 +25,200 @@
 -->
 <template>
   <div style="padding-top: 20px">
-    <a-form :label-col="labelCol" :wrapper-col="wrapperCol" :form="form" class="p0-32-10-32 form-content">
+    <a-form
+      :label-col="labelCol"
+      :wrapper-col="wrapperCol"
+      :form="form"
+      class="p0-32-10-32 form-content"
+    >
       <a-form-item label="队列名称">
-        <a-input id="error" v-decorator="[
+        <a-input
+          id="error"
+          v-decorator="[
             'queueName',
-            { rules: [{ required: true, message: '队列名称不能为空!' }, { validator: checkName }] },
-          ]" placeholder="请输入队列名称" />
+            {
+              rules: [
+                { required: true, message: '队列名称不能为空!' },
+                { validator: checkName },
+              ],
+            },
+          ]"
+          placeholder="请输入队列名称"
+        />
       </a-form-item>
-      <a-form-item label="最小资源数" style="margin-bottom: 0px" :required="true">
+      <a-form-item
+        label="最小资源数"
+        style="margin-bottom: 0px"
+        :required="true"
+      >
         <a-row type="flex" style="position: relative">
           <a-col :span="9">
             <a-form-item>
-              <a-input v-decorator="[
-                    `minCore`,
-                    {
+              <a-input
+                v-decorator="[
+                  `minCore`,
+                  {
                     rules: [
                       {
                         required: true,
                         message: `最小内核数不能为空!`,
                       },
-                      { validator: checkNumber }
+                      { validator: checkNumber },
                     ],
-                  }
-                  ]" placeholder="请输入" />
+                  },
+                ]"
+                placeholder="请输入"
+              />
             </a-form-item>
           </a-col>
           <a-col :span="2" style="text-align: right">Core</a-col>
           <a-col :span="2" style></a-col>
           <a-col :span="9">
             <a-form-item>
-              <a-input v-decorator="[
-                    `minMem`,
-                    {
+              <a-input
+                v-decorator="[
+                  `minMem`,
+                  {
                     rules: [
                       {
                         required: true,
                         message: `最小内存数不能为空`,
                       },
-                      { validator: checkNumber }
+                      { validator: checkNumber },
                     ],
-                  }
-                  ]" placeholder="请输入" />
+                  },
+                ]"
+                placeholder="请输入"
+              />
             </a-form-item>
           </a-col>
           <a-col :span="2" style="text-align: right">GB</a-col>
         </a-row>
       </a-form-item>
-      <a-form-item label="最大资源数" style="margin-bottom: 0px" :required="true">
+      <a-form-item
+        label="最大资源数"
+        style="margin-bottom: 0px"
+        :required="true"
+      >
         <a-row type="flex" style="position: relative">
           <a-col :span="9">
             <a-form-item>
-              <a-input v-decorator="[
-                    `maxCore`,
-                    {
+              <a-input
+                v-decorator="[
+                  `maxCore`,
+                  {
                     rules: [
                       {
                         required: true,
                         message: `最大内核数不能为空!`,
                       },
-                      { validator: checkNumber }
+                      { validator: checkNumber },
                     ],
-                  }
-                  ]" placeholder="请输入" />
+                  },
+                ]"
+                placeholder="请输入"
+              />
             </a-form-item>
           </a-col>
           <a-col :span="2" style="text-align: right">Core</a-col>
           <a-col :span="2" style></a-col>
           <a-col :span="9">
             <a-form-item>
-              <a-input v-decorator="[
-                    `maxMem`,
-                    {
+              <a-input
+                v-decorator="[
+                  `maxMem`,
+                  {
                     rules: [
                       {
                         required: true,
                         message: `最大内存数不能为空`,
                       },
-                      { validator: checkNumber }
+                      { validator: checkNumber },
                     ],
-                  }
-                  ]" placeholder="请输入" />
+                  },
+                ]"
+                placeholder="请输入"
+              />
             </a-form-item>
           </a-col>
           <a-col :span="2" style="text-align: right">GB</a-col>
         </a-row>
       </a-form-item>
       <a-form-item label="最多同时运行应用数">
-        <a-input id="error" v-decorator="[
+        <a-input
+          id="error"
+          v-decorator="[
             'appNum',
-            { rules: [{ required: true, message: '最多同时运行应用数不能为空!' }, { validator: checkNumber }] },
-          ]" placeholder="请输入最多同时运行应用数" />
+            {
+              rules: [
+                { required: true, message: '最多同时运行应用数不能为空!' },
+                { validator: checkNumber },
+              ],
+            },
+          ]"
+          placeholder="请输入最多同时运行应用数"
+        />
       </a-form-item>
       <a-form-item label="资源分配策略">
-        <a-select v-decorator="['schedulePolicy', { rules: [{ required: true, message: '资源分配策略不能为空!' }]}]" placeholder="请选择资源分配策略">
-          <a-select-option :value="item.label" v-for="(item,index) in schedulePolicyList" :key="index">{{item.label}}</a-select-option>
+        <a-select
+          v-decorator="[
+            'schedulePolicy',
+            { rules: [{ required: true, message: '资源分配策略不能为空!' }] },
+          ]"
+          placeholder="请选择资源分配策略"
+        >
+          <a-select-option
+            :value="item.label"
+            v-for="(item, index) in schedulePolicyList"
+            :key="index"
+            >{{ item.label }}</a-select-option
+          >
         </a-select>
       </a-form-item>
       <a-form-item label="权重">
-        <a-input id="error" v-decorator="[
+        <a-input
+          id="error"
+          v-decorator="[
             'weight',
-            { rules: [{ required: true, message: '权重不能为空!' }, { validator: checkNumber }] },
-          ]" placeholder="请输入权重" />
+            {
+              rules: [
+                { required: true, message: '权重不能为空!' },
+                { validator: checkNumber },
+              ],
+            },
+          ]"
+          placeholder="请输入权重"
+        />
       </a-form-item>
       <a-form-item label="队列中AM占用最大比例">
-        <a-input id="error" v-decorator="[
+        <a-input
+          id="error"
+          v-decorator="[
             'amShare',
-            { rules: [{ required: true, message: '队列中AM占用最大比例不能为空!' }, { validator: checkFloat }] },
-          ]" placeholder="请输入队列中AM占用最大比例" />
+            {
+              rules: [
+                { required: true, message: '队列中AM占用最大比例不能为空!' },
+                { validator: checkFloat },
+              ],
+            },
+          ]"
+          placeholder="请输入队列中AM占用最大比例"
+        />
       </a-form-item>
       <a-form-item label="是否允许队列抢占资源">
-        <a-switch v-decorator="[`allowPreemption`, { valuePropName: 'checked' }]"></a-switch>
+        <a-switch
+          v-decorator="[`allowPreemption`, { valuePropName: 'checked' }]"
+        ></a-switch>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
-      <a-button style="margin-right: 10px" type="primary" @click.stop="handleSubmit" :loading="loading">确认</a-button>
+    <div class="ant-modal-confirm-sure-btns-new">
+      <a-button
+        style="margin-right: 10px"
+        type="primary"
+        @click.stop="handleSubmit"
+        :loading="loading"
+        >确认</a-button
+      >
       <a-button @click.stop="formCancel">取消</a-button>
     </div>
   </div>
@@ -189,24 +269,18 @@ export default {
     checkNumber(rule, value, callback) {
       var reg = /^[1-9]\d*$/;
       if (!reg.test(value) && value) {
-        callback(
-          new Error("请输入正整数")
-        );
+        callback(new Error("请输入正整数"));
       }
       callback();
     },
 
-    checkFloat (rule, value, callback) {
+    checkFloat(rule, value, callback) {
       var reg = /^(([0-9])|([0-9]([0-9]+)))(.[0-9]+)?$/;
       if (!reg.test(value) && value) {
-        callback(
-          new Error("请输入正数")
-        );
+        callback(new Error("请输入正数"));
       }
       if (Number(value) === 0) {
-        callback(
-          new Error("请输入正数")
-        );
+        callback(new Error("请输入正数"));
       }
       callback();
     },
@@ -301,5 +375,4 @@ export default {
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/serviceManage/allotCharacter.vue
+++ b/datasophon-ui/src/pages/serviceManage/allotCharacter.vue
@@ -1,4 +1,3 @@
-
 <template>
   <div style="padding-top: 20px">
     <a-form
@@ -7,13 +6,25 @@
       :form="form"
       class="p0-32-10-32 form-content"
     >
-       <a-form-item label="角色组列表">
-           <a-select allowClear v-decorator="['characterGroupId', { rules: [{ required: true, message: '角色组列表不能为空!' }]}]"  placeholder="请选择告角色组列表">
-               <a-select-option :value="item.id" v-for="(item,index) in GroupList" :key="index">{{item.roleGroupName}}</a-select-option>
-          </a-select>
+      <a-form-item label="角色组列表">
+        <a-select
+          allowClear
+          v-decorator="[
+            'characterGroupId',
+            { rules: [{ required: true, message: '角色组列表不能为空!' }] },
+          ]"
+          placeholder="请选择告角色组列表"
+        >
+          <a-select-option
+            :value="item.id"
+            v-for="(item, index) in GroupList"
+            :key="index"
+            >{{ item.roleGroupName }}</a-select-option
+          >
+        </a-select>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"
@@ -40,13 +51,13 @@ export default {
         return {};
       },
     },
-    edit:{
-      type:Object,
+    edit: {
+      type: Object,
       default: function () {
         return {};
       },
     },
-    callBack:Function
+    callBack: Function,
   },
   data() {
     return {
@@ -62,57 +73,56 @@ export default {
       value1: "",
       loading: false,
       cateList: [], //类型
-      GroupList:[]  //列表
+      GroupList: [], //列表
     };
   },
-  watch: {
-  },
+  watch: {},
   methods: {
     formCancel() {
       this.$destroyAll();
     },
     handleSubmit(e) {
-      const _this = this
+      const _this = this;
       e.preventDefault();
       this.form.validateFields((err, values) => {
         if (!err) {
           const params = {
-            "roleInstanceIds":this.roleInstanceIds.join(),
-            "roleGroupId": values.characterGroupId,
-          }
+            roleInstanceIds: this.roleInstanceIds.join(),
+            roleGroupId: values.characterGroupId,
+          };
           this.loading = true;
-          this.$axiosPost(global.API.editRoleGroupBind, params).then((res) => {  
-            this.loading = false;
-            if (res.code !== 200) return
-            this.$message.success('分配角色成功')
-            this.$destroyAll();
-            _this.callBack();
-          }).catch((err) => {});
+          this.$axiosPost(global.API.editRoleGroupBind, params)
+            .then((res) => {
+              this.loading = false;
+              if (res.code !== 200) return;
+              this.$message.success("分配角色成功");
+              this.$destroyAll();
+              _this.callBack();
+            })
+            .catch((err) => {});
         }
       });
     },
     getServiceRoleType() {
-      const params={
-        serviceInstanceId :this.serviceId.id
-      }
+      const params = {
+        serviceInstanceId: this.serviceId.id,
+      };
       //角色组类型
       // this.$axiosPost(global.API.getServiceRoleType, params).then((res) => {
       //   if (res.code !== 200) return
       //   this.cateList = res.data
       // }
-      // ) 
+      // )
       //角色组列表
       this.$axiosPost(global.API.getRoleGroupList, params).then((res) => {
-        if (res.code !== 200) return  //this.$message.error('获取角色组列表失败')
-        this.GroupList = res.data
-        
-      })
-    }
+        if (res.code !== 200) return; //this.$message.error('获取角色组列表失败')
+        this.GroupList = res.data;
+      });
+    },
   },
   mounted() {
-    this.getServiceRoleType()
+    this.getServiceRoleType();
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/serviceManage/convertQueue.vue
+++ b/datasophon-ui/src/pages/serviceManage/convertQueue.vue
@@ -1,35 +1,93 @@
-
 <template>
   <div style="padding-top: 20px">
-    <a-form :label-col="labelCol" :wrapper-col="wrapperCol" :form="form" class="p0-32-10-32 form-content">
-      <a-form-item label="队列名称" >
-        <a-input :disabled="type =='show'"
-            v-decorator="['queueName', {rules: [{ required: true, message: '队列名称不能为空' }],initialValue:this.pageData.queueName || ''}]"
-            placeholder="请输入队列名称"
-          />
+    <a-form
+      :label-col="labelCol"
+      :wrapper-col="wrapperCol"
+      :form="form"
+      class="p0-32-10-32 form-content"
+    >
+      <a-form-item label="队列名称">
+        <a-input
+          :disabled="type == 'show'"
+          v-decorator="[
+            'queueName',
+            {
+              rules: [{ required: true, message: '队列名称不能为空' }],
+              initialValue: this.pageData.queueName || '',
+            },
+          ]"
+          placeholder="请输入队列名称"
+        />
       </a-form-item>
-      <a-form-item label="资源占比" >
-        <a-slider id="test" :disabled="type =='show'" 
-        v-decorator="['capacity', {rules: [{ required: true, message: '数据源不能为空' }],initialValue:Number(this.pageData.capacity || '0')}]"/>
+      <a-form-item label="资源占比">
+        <a-slider
+          id="test"
+          :disabled="type == 'show'"
+          v-decorator="[
+            'capacity',
+            {
+              rules: [{ required: true, message: '数据源不能为空' }],
+              initialValue: Number(this.pageData.capacity || '0'),
+            },
+          ]"
+        />
       </a-form-item>
-      <a-form-item label="关联标签" >
-        <a-select showSearch allowClear :disabled="type =='show'"
-          v-decorator="['nodeLabel', {rules: [{ required: true, message: '关联标签不能为空' }],
-          initialValue:this.pageData.nodeLabel}]" placeholder="请选择关联标签"  >
-          <a-select-option v-for="list in cateList" :key="list.nodeLabel" :value="list.nodeLabel"  :title="list.nodeLabel">  {{list.nodeLabel}} </a-select-option>
+      <a-form-item label="关联标签">
+        <a-select
+          showSearch
+          allowClear
+          :disabled="type == 'show'"
+          v-decorator="[
+            'nodeLabel',
+            {
+              rules: [{ required: true, message: '关联标签不能为空' }],
+              initialValue: this.pageData.nodeLabel,
+            },
+          ]"
+          placeholder="请选择关联标签"
+        >
+          <a-select-option
+            v-for="list in cateList"
+            :key="list.nodeLabel"
+            :value="list.nodeLabel"
+            :title="list.nodeLabel"
+          >
+            {{ list.nodeLabel }}
+          </a-select-option>
         </a-select>
       </a-form-item>
-      <a-form-item label="允许提交用户" >
-        <a-select showSearch allowClear :disabled="type =='show'" mode="multiple"
-          v-decorator="['aclUsers', {rules: [{ required: true, message: '允许提交用户不能为空' }],
-          initialValue:this.pageData.aclUsers?this.pageData.aclUsers.split(','):[]}]" placeholder="请选择允许提交用户"  >
-          <a-select-option v-for="list in userList" :key="list.username" :value="list.username"  :title="list.username">  {{list.username}} </a-select-option>
+      <a-form-item label="允许提交用户">
+        <a-select
+          showSearch
+          allowClear
+          :disabled="type == 'show'"
+          mode="multiple"
+          v-decorator="[
+            'aclUsers',
+            {
+              rules: [{ required: true, message: '允许提交用户不能为空' }],
+              initialValue: this.pageData.aclUsers
+                ? this.pageData.aclUsers.split(',')
+                : [],
+            },
+          ]"
+          placeholder="请选择允许提交用户"
+        >
+          <a-select-option
+            v-for="list in userList"
+            :key="list.username"
+            :value="list.username"
+            :title="list.username"
+          >
+            {{ list.username }}
+          </a-select-option>
         </a-select>
       </a-form-item>
     </a-form>
-    
-    <div class="ant-modal-confirm-btns-new">
-      <a-button  :disabled="type =='show'"
+
+    <div class="ant-modal-confirm-sure-btns-new">
+      <a-button
+        :disabled="type == 'show'"
         style="margin-right: 10px"
         type="primary"
         @click.stop="handleSubmit"
@@ -44,22 +102,22 @@
 export default {
   name: "convertQueue",
   props: {
-    obj:{
-      type:Object,
+    obj: {
+      type: Object,
       default: function () {
         return {};
       },
     },
-    type:{
-      type:String,
+    type: {
+      type: String,
       default: function () {
-        return '';
+        return "";
       },
     },
-    callBack:Function
+    callBack: Function,
   },
   data() {
-    console.log(this.obj,'this.obj')
+    console.log(this.obj, "this.obj");
     return {
       labelCol: {
         xs: { span: 24 },
@@ -72,8 +130,8 @@ export default {
       form: this.$form.createForm(this),
       loading: false,
       cateList: [], //类型
-      userList:[],  //列表
-      pageData:this.obj.data || {},
+      userList: [], //列表
+      pageData: this.obj.data || {},
       clusterId: Number(localStorage.getItem("clusterId") || -1),
     };
   },
@@ -84,9 +142,9 @@ export default {
     },
     getUserList() {
       this.$axiosPost(global.API.getTenant, {
-        pageSize:10000,
-        username:'',
-        page:1
+        pageSize: 10000,
+        username: "",
+        page: 1,
       }).then((res) => {
         this.userList = res.data || [];
       });
@@ -106,37 +164,40 @@ export default {
       this.form.validateFields((err, values) => {
         if (!err) {
           const params = {
-              "queueName":values.queueName,
-              "clusterId":_this.clusterId,
-              "capacity":values.capacity,
-              "nodeLabel":values.nodeLabel,
-              "aclUsers":values.aclUsers.join(','),
-          }
-          if(_this.pageData.id){
-            params['id'] = _this.pageData.id
-            params['parent'] = _this.pageData.parent
+            queueName: values.queueName,
+            clusterId: _this.clusterId,
+            capacity: values.capacity,
+            nodeLabel: values.nodeLabel,
+            aclUsers: values.aclUsers.join(","),
+          };
+          if (_this.pageData.id) {
+            params["id"] = _this.pageData.id;
+            params["parent"] = _this.pageData.parent;
           } else {
-            params['parent'] = _this.obj.parent
+            params["parent"] = _this.obj.parent;
           }
           this.loading = true;
-          this.$axiosJsonPost('/ddh/cluster/queue/capacity/'+this.type, params).then((res) => {  
-            this.loading = false;
-            if (res.code !== 200) return
-            this.$message.success('修改成功')
-            this.$destroyAll();
-            _this.callBack(params);
-          }).catch((err) => {});
+          this.$axiosJsonPost(
+            "/ddh/cluster/queue/capacity/" + this.type,
+            params
+          )
+            .then((res) => {
+              this.loading = false;
+              if (res.code !== 200) return;
+              this.$message.success("修改成功");
+              this.$destroyAll();
+              _this.callBack(params);
+            })
+            .catch((err) => {});
         }
       });
     },
   },
-  created(){
+  created() {
     this.getUserList();
     this.getLabelList();
   },
-  mounted() {
-  },
+  mounted() {},
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/serviceManage/renameGroup.vue
+++ b/datasophon-ui/src/pages/serviceManage/renameGroup.vue
@@ -1,4 +1,3 @@
-
 <template>
   <div style="padding-top: 20px">
     <a-form
@@ -18,7 +17,7 @@
         />
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"
@@ -33,13 +32,13 @@
 <script>
 export default {
   props: {
-    grouopObj:{
-      type:Object,
+    grouopObj: {
+      type: Object,
       default: function () {
         return {};
       },
     },
-    callBack:Function
+    callBack: Function,
   },
   data() {
     return {
@@ -55,7 +54,7 @@ export default {
       value1: "",
       loading: false,
       cateList: [], //类型
-      GroupList:[]  //列表
+      GroupList: [], //列表
     };
   },
   watch: {},
@@ -64,40 +63,39 @@ export default {
       this.$destroyAll();
     },
     handleSubmit(e) {
-      const _this = this
+      const _this = this;
       e.preventDefault();
       this.form.validateFields((err, values) => {
         if (!err) {
           const params = {
-            "roleGroupName": values.roleGroupName, 
-            "roleGroupId": this.grouopObj.id,
-          }
+            roleGroupName: values.roleGroupName,
+            roleGroupId: this.grouopObj.id,
+          };
           this.loading = true;
-          this.$axiosPost(global.API.reNameGroup, params).then((res) => {  
-            this.loading = false;
-            if (res.code !== 200) return
-            this.$message.success('修改成功')
-            this.$destroyAll();
-            _this.callBack(params);
-          }).catch((err) => {});
+          this.$axiosPost(global.API.reNameGroup, params)
+            .then((res) => {
+              this.loading = false;
+              if (res.code !== 200) return;
+              this.$message.success("修改成功");
+              this.$destroyAll();
+              _this.callBack(params);
+            })
+            .catch((err) => {});
         }
       });
     },
-    initData () {
+    initData() {
       if (JSON.stringify(this.grouopObj) !== "{}") {
-        this.form.getFieldsValue([
-          "roleGroupName"
-        ]);
+        this.form.getFieldsValue(["roleGroupName"]);
         this.form.setFieldsValue({
-          roleGroupName: this.grouopObj.roleGroupName
+          roleGroupName: this.grouopObj.roleGroupName,
         });
-      } 
-    }
+      }
+    },
   },
   mounted() {
-    this.initData()
+    this.initData();
   },
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/systemCenter/commponents/addUser.vue
+++ b/datasophon-ui/src/pages/systemCenter/commponents/addUser.vue
@@ -82,7 +82,7 @@
         </a-select>
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"
@@ -127,9 +127,15 @@ export default {
       var reg = /[\u4E00-\u9FA5]|[\uFE30-\uFFA0]/g;
       if (reg.test(value)) {
         callback(new Error("名称中不能包含中文"));
+        return;
       }
       if (/\s/g.test(value)) {
         callback(new Error("名称中不能包含空格"));
+        return;
+      }
+      if (value && value.length <= 2) {
+        callback(new Error("名称长度必须大于2个字符"));
+        return;
       }
       callback();
     },

--- a/datasophon-ui/src/pages/systemCenter/commponents/addUserGroup.vue
+++ b/datasophon-ui/src/pages/systemCenter/commponents/addUserGroup.vue
@@ -25,16 +25,35 @@
 -->
 <template>
   <div style="padding-top: 10px">
-    <a-form :label-col="labelCol" :wrapper-col="wrapperCol" :form="form" class="p0-32-10-32 form-content">
+    <a-form
+      :label-col="labelCol"
+      :wrapper-col="wrapperCol"
+      :form="form"
+      class="p0-32-10-32 form-content"
+    >
       <a-form-item label="用户组名称">
-        <a-input v-decorator="[
+        <a-input
+          v-decorator="[
             'groupName',
-            { rules: [{ required: true, message: '用户组名称不能为空!' }, { validator: checkName }] },
-          ]" placeholder="请输入用户组名称" />
+            {
+              rules: [
+                { required: true, message: '用户组名称不能为空!' },
+                { validator: checkName },
+              ],
+            },
+          ]"
+          placeholder="请输入用户组名称"
+        />
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
-      <a-button style="margin-right: 10px" type="primary" @click.stop="handleSubmit" :loading="loading">确认</a-button>
+    <div class="ant-modal-confirm-sure-btns-new">
+      <a-button
+        style="margin-right: 10px"
+        type="primary"
+        @click.stop="handleSubmit"
+        :loading="loading"
+        >确认</a-button
+      >
       <a-button @click.stop="formCancel">取消</a-button>
     </div>
   </div>
@@ -63,7 +82,7 @@ export default {
       },
       form: this.$form.createForm(this),
       loading: false,
-      groupList:[],
+      groupList: [],
     };
   },
   watch: {},
@@ -88,10 +107,10 @@ export default {
         if (!err) {
           const params = {
             groupName: values.groupName,
-            clusterId: Number(localStorage.getItem("clusterId") || '-1'),
+            clusterId: Number(localStorage.getItem("clusterId") || "-1"),
           };
           this.loading = true;
-          this.$axiosPost('/ddh/cluster/group/save', params)
+          this.$axiosPost("/ddh/cluster/group/save", params)
             .then((res) => {
               this.loading = false;
               if (res.code === 200) {
@@ -105,9 +124,7 @@ export default {
       });
     },
   },
-  mounted() {
-  },
+  mounted() {},
 };
 </script>
-<style lang="less" scoped>
-</style>
+<style lang="less" scoped></style>

--- a/datasophon-ui/src/pages/systemCenter/frame/commponents/addFrame.vue
+++ b/datasophon-ui/src/pages/systemCenter/frame/commponents/addFrame.vue
@@ -41,7 +41,7 @@
         />
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"

--- a/datasophon-ui/src/pages/systemCenter/tag/commponents/addTag.vue
+++ b/datasophon-ui/src/pages/systemCenter/tag/commponents/addTag.vue
@@ -41,7 +41,7 @@
         />
       </a-form-item>
     </a-form>
-    <div class="ant-modal-confirm-btns-new">
+    <div class="ant-modal-confirm-sure-btns-new">
       <a-button
         style="margin-right: 10px"
         type="primary"


### PR DESCRIPTION
<!--Thanks very much for contributing to DataSophon. Please review https://datasophon.github.io/datasophon-website/docs/current/%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE/pull_request before opening a pull request.-->

## Purpose of the pull request
Fixes #18 
1.弹窗组件底部按钮样式
2.添加用户form表单中用户名称的正则校验
<img width="532" height="292" alt="image" src="https://github.com/user-attachments/assets/232e9eb9-104e-4197-882a-e9e9ce2b8674" /><!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root [pom.xml*](url)
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added datasophon-infrastructure tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contains incompatible changes, you should also pull request the documentation to `https://github.com/datasophon/datasophon-website`
